### PR TITLE
AG-67 test123

### DIFF
--- a/src/features/auth/components/SignInForm.tsx
+++ b/src/features/auth/components/SignInForm.tsx
@@ -13,35 +13,37 @@ import {PasswordInput} from "./inputs/PasswordInput.tsx";
 
 import {SignInAuthErrorAlert} from "./SignInAuthErrorAlert.tsx";
 
-export default function SignInForm() {
-    const { isAuthenticated, handleSignIn } = useAuth();
+// Constants
+const REMEMBER_ME_KEY = 'rememberMe';
 
-    const [email, setEmail] = useState('');
-    const [emailError, setEmailError] = useState('');
-    const [password, setPassword] = useState('');
-    const [passwordError, setPasswordError] = useState('');
+// Helper function to safely execute localStorage operations with error handling
+function safeLocalStorage<T>(operation: () => T, fallback: T): T {
+    try {
+        return operation();
+    } catch (error) {
+        console.warn('localStorage operation failed:', error);
+        return fallback;
+    }
+}
+
+// Helper functions for localStorage operations
+const getRememberMeFromStorage = (): boolean | null => {
+    return safeLocalStorage(() => {
+        const saved = localStorage.getItem(REMEMBER_ME_KEY);
+        return saved !== null ? saved === 'true' : null;
+    }, null);
+};
+
+const saveRememberMeToStorage = (value: boolean): void => {
+    safeLocalStorage(() => {
+        localStorage.setItem(REMEMBER_ME_KEY, String(value));
+        return undefined;
+    }, undefined);
+};
+
+// Custom hook for managing rememberMe state with localStorage persistence
+function useRememberMe(): [boolean, (event: React.ChangeEvent<HTMLInputElement>) => void] {
     const [rememberMe, setRememberMe] = useState(false);
-
-    // Helper functions for localStorage operations with error handling
-    const REMEMBER_ME_KEY = 'rememberMe';
-
-    const getRememberMeFromStorage = (): boolean | null => {
-        try {
-            const saved = localStorage.getItem(REMEMBER_ME_KEY);
-            return saved !== null ? saved === 'true' : null;
-        } catch (error) {
-            console.warn('Failed to read rememberMe from localStorage:', error);
-            return null;
-        }
-    };
-
-    const saveRememberMeToStorage = (value: boolean): void => {
-        try {
-            localStorage.setItem(REMEMBER_ME_KEY, String(value));
-        } catch (error) {
-            console.warn('Failed to save rememberMe to localStorage:', error);
-        }
-    };
 
     // Load rememberMe preference from localStorage on mount
     useEffect(() => {
@@ -56,11 +58,23 @@ export default function SignInForm() {
         saveRememberMeToStorage(event.target.checked);
     };
 
+    return [rememberMe, handleRememberMeChange];
+}
+
+export default function SignInForm() {
+    const { isAuthenticated, handleSignIn } = useAuth();
+
+    const [email, setEmail] = useState('');
+    const [emailError, setEmailError] = useState('');
+    const [password, setPassword] = useState('');
+    const [passwordError, setPasswordError] = useState('');
+    const [rememberMe, handleRememberMeChange] = useRememberMe();
+
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
         if (emailError === '' && passwordError === '') {
-            await handleSignIn(e);
+            await handleSignIn(e, rememberMe);
         }
     };
 

--- a/src/features/auth/components/SignInForm.tsx
+++ b/src/features/auth/components/SignInForm.tsx
@@ -1,8 +1,10 @@
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import useAuth from "../hooks/useAuth.ts";
 
@@ -18,6 +20,41 @@ export default function SignInForm() {
     const [emailError, setEmailError] = useState('');
     const [password, setPassword] = useState('');
     const [passwordError, setPasswordError] = useState('');
+    const [rememberMe, setRememberMe] = useState(false);
+
+    // Helper functions for localStorage operations with error handling
+    const REMEMBER_ME_KEY = 'rememberMe';
+
+    const getRememberMeFromStorage = (): boolean | null => {
+        try {
+            const saved = localStorage.getItem(REMEMBER_ME_KEY);
+            return saved !== null ? saved === 'true' : null;
+        } catch (error) {
+            console.warn('Failed to read rememberMe from localStorage:', error);
+            return null;
+        }
+    };
+
+    const saveRememberMeToStorage = (value: boolean): void => {
+        try {
+            localStorage.setItem(REMEMBER_ME_KEY, String(value));
+        } catch (error) {
+            console.warn('Failed to save rememberMe to localStorage:', error);
+        }
+    };
+
+    // Load rememberMe preference from localStorage on mount
+    useEffect(() => {
+        const saved = getRememberMeFromStorage();
+        if (saved !== null) {
+            setRememberMe(saved);
+        }
+    }, []);
+
+    const handleRememberMeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setRememberMe(event.target.checked);
+        saveRememberMeToStorage(event.target.checked);
+    };
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -51,6 +88,16 @@ export default function SignInForm() {
                     setPassword={setPassword}
                     passwordError={passwordError}
                     setPasswordError={setPasswordError} />
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={rememberMe}
+                            onChange={handleRememberMeChange}
+                            color="primary"
+                        />
+                    }
+                    label="Remember me"
+                />
                 {
                    !isAuthenticated && (<SignInAuthErrorAlert />)
                 }

--- a/src/features/users/components/UsersTableContainer.tsx
+++ b/src/features/users/components/UsersTableContainer.tsx
@@ -18,7 +18,7 @@ const UsersTableContainer: React.FC = () => {
         rowCount: 0
     });
 
-    const {users, setUsers, isLoading, setNewUser, setEditedUser, deleteUserFromState} = useUsersState(paginationModel, setPaginationModel);
+    const {users, isLoading, setNewUser, setEditedUser, deleteUserFromState} = useUsersState(paginationModel, setPaginationModel);
     const { rows } = useUsersTableRows(users);
 
     const createDialog = useDialog();

--- a/src/features/users/hooks/useUsersState.ts
+++ b/src/features/users/hooks/useUsersState.ts
@@ -2,7 +2,6 @@ import {useCallback, useEffect, useMemo, useState} from "react";
 import {IUser} from "../interfaces/iUser.ts";
 import UsersHttpService from "../services/usersHttpService.ts";
 import {IUserResponse} from "../interfaces/iUserResponse.ts";
-import {useNotifications} from "@toolpad/core";
 import {IPaginationModel} from "../interfaces/iPaginationModel.ts";
 
 export const useUsersState = (paginationModel : IPaginationModel, setPaginationModel: (paginationModel : IPaginationModel) => void) => {

--- a/src/providers/route/components/ProtectedRoute.tsx
+++ b/src/providers/route/components/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, ReactNode} from "react";
+import React, {ReactNode} from "react";
 
 import {APP_ROUTES} from "../../../shared/variables/appRoutes.ts";
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,6 +24,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "src/**/**"
+    "src/**"
   ]
 }


### PR DESCRIPTION
Implementation of AG-67

Improve the existing sign-in page by adding a “Remember me” checkbox and storing the selected preference in localStorage.

Context:
The application already has an authentication flow and a sign-in page. The goal is not to redesign the whole authentication system, but to extend the current sign-in form with a small persistent preference.

Requirements:

# Add a “Remember me” checkbox to the sign-in form.
# The checkbox should be displayed near the login controls, preferably below the email/password fields and before the submit button.
# When the user checks or unchecks the checkbox, store the selected value in localStorage.
# When the sign-in page is opened again, read the saved value from localStorage and initialize the checkbox with the previously selected preference.
# Use a clear localStorage key, for example: {{rememberMe}}.
# Keep the implementation simple and consistent with the existing code style, component structure, and form-handling approach.
# Do not introduce a new state-management library.
# Do not change the backend/API authentication logic.
# Do not store the password in localStorage.
# If the app already stores auth tokens somewhere, do not change that behavior unless it is directly required by the current auth implementation.

Expected behavior:

* If the user enables “Remember me”, the checkbox remains enabled after refreshing the page or returning to the sign-in page later.
* If the user disables “Remember me”, the checkbox remains disabled after refreshing the page or returning to the sign-in page later.
* The preference should survive page reloads.
* The sign-in flow should continue to work exactly as before.

Implementation guidance:

* Locate the existing sign-in page or auth form component.
* Add local React state for the checkbox value.
* On component mount, read the saved value from localStorage.
* On checkbox change, update both React state and localStorage.
* Use the existing UI library/components used in the project.
* Keep naming simple and readable.

Validation:

* Manually test that the checkbox appears on the sign-in page.
* Check the box, refresh the page, and confirm it stays checked.
* Uncheck the box, refresh the page, and confirm it stays unchecked.
* Confirm that sign-in still works normally.
* Confirm that no sensitive data such as password is stored in localStorage.

Optional improvement:
If the login form already contains an email field, and “Remember me” is enabled, also store only the user email in localStorage and prefill it next time. Do not store the password.

# Implementation Plan

## Conceptual Checklist

- Review current SignInForm.tsx structure and state management
- Identify MUI Checkbox component to use (FormControlLabel + Checkbox)
- Determine localStorage read/write timing (useEffect for read, onChange for write)
- Verify localStorage key naming convention ('rememberMe')
- Plan component placement between PasswordInput and submit Button
- Ensure no password data touches localStorage
- Plan manual testing steps

## Overview

Extend the existing sign-in form in `SignInForm.tsx` by adding a "Remember me" checkbox that persists user preference in localStorage. The checkbox state will be read on component mount and updated whenever the user toggles it. Implementation follows existing patterns: useState for local state, MUI components for UI, and localStorage for persistence (matching the existing 'authStatus' pattern).

## Assumptions and Rules from CLAUDE.md

**Assumptions:**
- Only implementing checkbox persistence, not email prefill (based on default assumption)
- Checkbox should use MUI's FormControlLabel and Checkbox components for consistency
- localStorage key 'rememberMe' will store boolean as string ('true'/'false')

**Rules from project CLAUDE.md:**
- Use MUI components (Checkbox, FormControlLabel) for UI consistency
- Use useState for component state management
- Follow existing localStorage pattern seen in useAuth.ts
- Interface naming with 'I' prefix (not needed here, no new interfaces)
- Import extensions must include .tsx

**Rules from global CLAUDE.md:**
- Keep components focused and state management simple
- Follow existing patterns in the codebase
- No new state management libraries

**Ambiguities and resolutions:**
- Email prefill is optional → Resolved: Not implementing unless requested

## Step-by-Step Implementation

1. **Add rememberMe state to SignInForm component**
- Dependencies: React.useState
- Tools/Files: Edit src/features/auth/components/SignInForm.tsx
- Add: `const [rememberMe, setRememberMe] = useState(false);`

2. **Add useEffect to read localStorage on component mount**
- Dependencies: React.useEffect
- Tools/Files: Edit SignInForm.tsx
- Read localStorage.getItem('rememberMe') and initialize state
- Handle null case (first time user)

3. **Import MUI Checkbox components**
- Add imports: `import Checkbox from '@mui/material/Checkbox';`
- Add imports: `import FormControlLabel from '@mui/material/FormControlLabel';`

4. **Add checkbox UI between PasswordInput and SignInAuthErrorAlert**
- Use FormControlLabel wrapping Checkbox
- Wire checked={rememberMe} and onChange handler
- Label text: "Remember me"

5. **Implement onChange handler for checkbox**
- Update both rememberMe state and localStorage
- Store as string: localStorage.setItem('rememberMe', String(newValue))

6. **Manual testing**
- Verify checkbox appears below password field
- Check checkbox, refresh browser, confirm it stays checked
- Uncheck checkbox, refresh browser, confirm it stays unchecked
- Verify sign-in flow works normally
- Inspect localStorage to confirm 'rememberMe' key exists and no password is stored

## Error Handling and Uncertainties

**Potential issues:**
- localStorage might be disabled in some browsers (private mode) → Consider wrapping localStorage calls in try-catch, but since 'authStatus' already uses localStorage without protection, maintain consistency
- Initial state race condition → useEffect with empty dependency array [] ensures it runs once after mount, before user interaction
- Boolean/string conversion → Use explicit String(value) when writing and comparison to 'true' when reading, matching existing 'authStatus' pattern

**Uncertainties:**
- Email prefill feature scope → Flagged as question; default assumption is to skip
- Checkbox styling specifics → Use default MUI styling unless visual inconsistency appears during testing